### PR TITLE
fix(grid): 修复布局组件Column只设置某几种断点下的栅格时自动布局有误的问题

### DIFF
--- a/docs/docs/components/grid.mdx
+++ b/docs/docs/components/grid.mdx
@@ -698,7 +698,7 @@ export default function Demo() {
 ## 自动布局
 
 - 若 Column 组件没有设置 xs、sm、md、lg、xs 属性值,则在断点对应尺寸下每列平均分配剩余空间。
-- 如果 Column 组件通过 style 属性或者 ClassName 设置了 width 样式(设置 width 的同时还需要设置 flow-grow:1 以防止存在剩余空间时列会自动伸展)，则列宽为设置的 width 值。
+- 如果 Column 组件通过 style 属性或者 ClassName 设置了 width 样式(设置 width 的同时还需要设置 flow-grow:0 以防止存在剩余空间时列会自动伸展)，则列宽为设置的 width 值。
 
 Demo.tsx
 

--- a/docs/docs/components/grid.mdx
+++ b/docs/docs/components/grid.mdx
@@ -65,9 +65,6 @@ export default function Demo() {
           <Column xs={12}>
             <div>col-xs-12</div>
           </Column>
-          <Column xs={12}>
-            <div>col-xs-12</div>
-          </Column>
         </Row>
       </Wrapper>
     </ThemeProvider>
@@ -108,9 +105,6 @@ export default function Demo() {
           <Column xs={12}>
             <div>col-xs-12</div>
           </Column>
-          <Column xs={12}>
-            <div>col-xs-12</div>
-          </Column>
         </Row>
       </Wrapper>
     </ThemeProvider>
@@ -142,9 +136,6 @@ export default function Demo() {
     <ThemeProvider theme={defaultTheme}>
       <Wrapper>
         <Row gutterType="around" gutter={8}>
-          <Column xs={12}>
-            <div>col-xs-12</div>
-          </Column>
           <Column xs={12}>
             <div>col-xs-12</div>
           </Column>
@@ -691,9 +682,6 @@ export default function Demo() {
           <Column xs={12} sm={6} md={4} lg={3}>
             <div>col-xs-12,col-sm-6,col-md-4,col-lg-3</div>
           </Column>
-          <Column xs={12} sm={6} md={4} lg={3}>
-            <div>col-xs-12,col-sm-6,col-md-4,col-lg-3</div>
-          </Column>
         </Row>
       </Wrapper>
     </ThemeProvider>
@@ -709,8 +697,8 @@ export default function Demo() {
 
 ## 自动布局
 
-- 如果 Column 组件没有设置任何 xs、sm、md、lg、xs 属性值,则每列平均分配剩余空间。
-- 如果 Column 组件通过 style 属性或者 ClassName 设置了 width 样式，则列宽为设置的 width 值。
+- 若 Column 组件没有设置 xs、sm、md、lg、xs 属性值,则在断点对应尺寸下每列平均分配剩余空间。
+- 如果 Column 组件通过 style 属性或者 ClassName 设置了 width 样式(设置 width 的同时还需要设置 flow-grow:1 以防止存在剩余空间时列会自动伸展)，则列宽为设置的 width 值。
 
 Demo.tsx
 
@@ -730,8 +718,8 @@ export default function Demo() {
           <Column style={{ width: '200px' }}>
             <div>width: 200px</div>
           </Column>
-          <Column>
-            <div>auto</div>
+          <Column sm={24}>
+            <div>col-sm-24,其余auto</div>
           </Column>
           <Column>
             <div>auto</div>

--- a/src/Grid/Column.ts
+++ b/src/Grid/Column.ts
@@ -77,7 +77,6 @@ const breakpointsCss = css((props: Props & { theme: Theme }) => {
     const mediaKey = `@media screen and (min-width: ${props.theme.breakpoints[item]}px)`;
     if (colNum && colNum > 0) {
       mediaResult[mediaKey] = {
-        ...mediaResult[mediaKey],
         width: `${(Math.min(colNum, 24) / 24) * 100}%`,
         flexBasis: `${(Math.min(colNum, 24) / 24) * 100}%`,
         flexGrow: 0,

--- a/src/Grid/Column.ts
+++ b/src/Grid/Column.ts
@@ -69,45 +69,18 @@ const breakpointKeys: Array<'xs' | 'sm' | 'md' | 'lg' | 'xl'> = [
   'xl',
 ];
 
-/**
- * 对应断点尺寸是否需要设置flex-grow: 1
- * @param props
- * @param breakpointKey
- */
-const isFlexGrow = (
-  props: Props,
-  breakpointKey: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
-): boolean => {
-  let breakpointKeyIndex = breakpointKeys.findIndex(
-    (item) => item === breakpointKey,
-  );
-  // 判断对应断点是否设置了栅格
-  if (!props[breakpointKey]) {
-    //  则递归判断小于断点之前的断点是否设置了栅格 若都没有设置栅格 则flex-grow: 1,否则应用前一个断点的栅格数
-    if (breakpointKeyIndex > 0) {
-      breakpointKeyIndex -= breakpointKeyIndex;
-      isFlexGrow(props, breakpointKeys[breakpointKeyIndex]);
-    }
-
-    return !props[breakpointKey];
-  }
-  return false;
-};
-
 const breakpointsCss = css((props: Props & { theme: Theme }) => {
   return breakpointKeys.reduce((result, item) => {
     const mediaResult = result;
     // colNum 为栅格数
     const colNum = props[item];
     const mediaKey = `@media screen and (min-width: ${props.theme.breakpoints[item]}px)`;
-    mediaResult[mediaKey] = {
-      flexGrow: isFlexGrow(props, item) ? 1 : 0,
-    };
     if (colNum && colNum > 0) {
       mediaResult[mediaKey] = {
         ...mediaResult[mediaKey],
         width: `${(Math.min(colNum, 24) / 24) * 100}%`,
         flexBasis: `${(Math.min(colNum, 24) / 24) * 100}%`,
+        flexGrow: 0,
       };
     }
     return mediaResult;
@@ -119,7 +92,7 @@ const Column = styled.div.attrs(() => ({
 }))<Props>`
   display: block;
   box-sizing: border-box;
-  flex: 0 0 auto;
+  flex: 1 0 auto;
   ${(props) => props.flexContainer && flexCss}
   ${breakpointsCss}
 `;

--- a/src/Grid/__snapshots__/Column.test.tsx.snap
+++ b/src/Grid/__snapshots__/Column.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`布局Column快照测试 栅格布局 1`] = `
   className="Row-y6j5gl-0 irTaBg sinoui-row"
 >
   <div
-    className="Column-sc-1ur4nb2-0 jHnFuz sinoui-column"
+    className="Column-sc-1ur4nb2-0 brKVZI sinoui-column"
   >
     列
   </div>
@@ -17,7 +17,7 @@ exports[`布局Column快照测试 默认 1`] = `
   className="Row-y6j5gl-0 irTaBg sinoui-row"
 >
   <div
-    className="Column-sc-1ur4nb2-0 iAzOVE sinoui-column"
+    className="Column-sc-1ur4nb2-0 bdxSkG sinoui-column"
   >
     列
   </div>

--- a/src/Grid/__snapshots__/Column.test.tsx.snap
+++ b/src/Grid/__snapshots__/Column.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`布局Column快照测试 栅格布局 1`] = `
   className="Row-y6j5gl-0 irTaBg sinoui-row"
 >
   <div
-    className="Column-sc-1ur4nb2-0 gFkKzz sinoui-column"
+    className="Column-sc-1ur4nb2-0 jHnFuz sinoui-column"
   >
     列
   </div>
@@ -17,7 +17,7 @@ exports[`布局Column快照测试 默认 1`] = `
   className="Row-y6j5gl-0 irTaBg sinoui-row"
 >
   <div
-    className="Column-sc-1ur4nb2-0 bdxSkG sinoui-column"
+    className="Column-sc-1ur4nb2-0 iAzOVE sinoui-column"
   >
     列
   </div>

--- a/stories/gridDemo/GridColumnWidth.tsx
+++ b/stories/gridDemo/GridColumnWidth.tsx
@@ -20,11 +20,11 @@ export default function Demo({
           justifyContent={justifyContent}
           alignItems={alignItems}
         >
-          <Column style={{ width: '200px' }}>
+          <Column style={{ width: '200px', flexGrow: 0 }}>
             <div>width: 200px</div>
           </Column>
-          <Column>
-            <div>auto</div>
+          <Column sm={24}>
+            <div>col-sm-24,其余auto</div>
           </Column>
           <Column>
             <div>auto</div>

--- a/stories/gridDemo/GridColumnWidth.tsx
+++ b/stories/gridDemo/GridColumnWidth.tsx
@@ -23,8 +23,8 @@ export default function Demo({
           <Column style={{ width: '200px', flexGrow: 0 }}>
             <div>width: 200px</div>
           </Column>
-          <Column sm={24}>
-            <div>col-sm-24,其余auto</div>
+          <Column sm={12} xs={24} md={8}>
+            <div>sm-12,xs-24,md-8</div>
           </Column>
           <Column>
             <div>auto</div>

--- a/stories/gridDemo/GridDemo.tsx
+++ b/stories/gridDemo/GridDemo.tsx
@@ -29,9 +29,6 @@ export default function Demo({
           <Column xs={12}>
             <div>col-xs-12</div>
           </Column>
-          <Column xs={12}>
-            <div>col-xs-12</div>
-          </Column>
         </Row>
       </Wrapper>
     </ThemeProvider>

--- a/stories/gridDemo/GridDemoResponse.tsx
+++ b/stories/gridDemo/GridDemoResponse.tsx
@@ -38,10 +38,7 @@ export default function Demo({
           <Column xs={24} sm={12} md={6} lg={4}>
             <div>col-xs-24,col-sm-12,col-md-6,col-lg-4</div>
           </Column>
-          <Column xs={24} sm={12} md={6} lg={4}>
-            <div>col-xs-24,col-sm-12,col-md-6,col-lg-4</div>
-          </Column>
-          <Column xs={24} sm={12} md={6} lg={4}>
+          <Column sm={12} md={6} lg={4}>
             <div>col-xs-24,col-sm-12,col-md-6,col-lg-4</div>
           </Column>
         </Row>


### PR DESCRIPTION
- 若Column组件只设置了xs属性，那么在其他几种断点情况下Column的宽度为xs断点下的宽度，而不是自动伸展
- 若Column组件只设置了sm属性，那么只有在xs断点情况下Column的宽度自动伸展，其余断点下Column都保持sm断点下的宽度